### PR TITLE
Fix GitHub Actions set-output deprecation

### DIFF
--- a/.github/workflows/test_self_hosted.yml
+++ b/.github/workflows/test_self_hosted.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           actions_user_id=`id -u $USER`
           echo $actions_user_id
-          echo ::set-output name=uid::$actions_user_id
+          echo "uid=$actions_user_id" >> $GITHUB_OUTPUT
 
       - name: Invoke Action
         uses: peter-murray/reset-permissions-action@main

--- a/.github/workflows/test_self_hosted_with_directory.yml
+++ b/.github/workflows/test_self_hosted_with_directory.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           actions_user_id=`id -u $USER`
           echo $actions_user_id
-          echo ::set-output name=uid::$actions_user_id
+          echo "uid=$actions_user_id" >> $GITHUB_OUTPUT
 
       - name: Invoke Action
         uses: peter-murray/reset-permissions-action@main

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can utilize an action step like the following to expose the UID of the GitHu
   run: |
     actions_user_id=`id -u $USER`
     echo $actions_user_id
-    echo ::set-output name=uid::$actions_user_id
+    echo "uid=$actions_user_id" >> $GITHUB_OUTPUT
 ```
 
 
@@ -63,7 +63,7 @@ Obtain the UID of the GitHub Actions runner and then correct any directories and
   run: |
     actions_user_id=`id -u $USER`
     echo $actions_user_id
-    echo ::set-output name=uid::$actions_user_id
+    echo "uid=$actions_user_id" >> $GITHUB_OUTPUT
 
 - name: Correct Ownership in GITHUB_WORKSPACE directory
   uses: peter-murray/reset-workspace-ownership-action@v1


### PR DESCRIPTION
Great GitHub Action!  It just helped me out of a jam.  :)

Resolves https://github.com/peter-murray/reset-workspace-ownership-action/issues/3

Copied from issue:
> GitHub Actions' set-output is kicking up deprecation warnings.  This PR hopefully addresses that.
> 
> Blog link:
> https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
> 
> Deprecation warning:
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/GitHub Actions' set-output is kicking up deprecation warnings.  Please expect a PR shortly.
> 
> Blog link:
> https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
> 
> Deprecation warning:
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/